### PR TITLE
Bugfix: Fix windows platform detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 BUILDDIR=$(ROOTDIR)/_build
 
-ifeq ($(WIN32), 1)
-INCLUDE=$(BUILDDIR)/glfw/include
-LIBRARY=$(BUILDDIR)/glfw/src
-else
+ifeq ($(WIN32),"1")
 INCLUDE=$(ROOTDIR)/include
 LIBRARY=$(ROOTDIR)/lib-mingw-w64
 ADDITIONAL_OPTS=-cclib -lgdi32
+else
+INCLUDE=$(BUILDDIR)/glfw/include
+LIBRARY=$(BUILDDIR)/glfw/src
 endif
 
 # Building glfw from source
@@ -26,6 +26,7 @@ build-glfw: $(LIBRARY)/libglfw3.a
 	mkdir -p $(BUILDDIR)
 
 install:
+	echo Win32: $(WIN32)
 	@echo Installing from $(LIBRARY) to $(LIBDIR)
 	@mkdir -p $(LIBDIR)
 	@cp $(LIBRARY)/*.a $(LIBDIR)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BUILDDIR=$(ROOTDIR)/_build
 
-ifeq ($(WIN32),"1")
+ifeq ($(WIN32),1)
 INCLUDE=$(ROOTDIR)/include
 LIBRARY=$(ROOTDIR)/lib-mingw-w64
 ADDITIONAL_OPTS=-cclib -lgdi32
@@ -26,7 +26,6 @@ build-glfw: $(LIBRARY)/libglfw3.a
 	mkdir -p $(BUILDDIR)
 
 install:
-	echo Win32: $(WIN32)
 	@echo Installing from $(LIBRARY) to $(LIBDIR)
 	@mkdir -p $(LIBDIR)
 	@cp $(LIBRARY)/*.a $(LIBDIR)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BUILDDIR=$(ROOTDIR)/_build
 
-ifeq (, $(shell which x86_64-w64-mingw32-g++))
+ifeq ($(WIN32), 1)
 INCLUDE=$(BUILDDIR)/glfw/include
 LIBRARY=$(BUILDDIR)/glfw/src
 else

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "esy": {
     "build": [
-        ["make", "#{os == 'windows' ? 'noop' : 'build-glfw'}", "ROOTDIR=#{self.root}"],
-        ["make", "install", "ROOTDIR=#{self.root}", "LIBDIR=#{self.lib}", "INCLUDEDIR=#{self.install / 'include'}"]
+        ["make", "#{os == 'windows' ? 'noop' : 'build-glfw'}", "ROOTDIR=#{self.root}", "WIN32={#os=='windows' ? '1' : '0'}"],
+        ["make", "install", "ROOTDIR=#{self.root}", "LIBDIR=#{self.lib}", "INCLUDEDIR=#{self.install / 'include'}", "WIN32={#os=='windows' ? '1': '0'}"]
     ],
     "buildsInSource":"_build",
     "exportedEnv": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "esy": {
     "build": [
-        ["make", "#{os == 'windows' ? 'noop' : 'build-glfw'}", "ROOTDIR=#{self.root}", "WIN32={#os=='windows' ? '1' : '0'}"],
-        ["make", "install", "ROOTDIR=#{self.root}", "LIBDIR=#{self.lib}", "INCLUDEDIR=#{self.install / 'include'}", "WIN32={#os=='windows' ? '1': '0'}"]
+        ["make", "#{os == 'windows' ? 'noop' : 'build-glfw'}", "ROOTDIR=#{self.root}", "WIN32=#{os == 'windows' ? '1' : '0'}"],
+        ["make", "install", "ROOTDIR=#{self.root}", "LIBDIR=#{self.lib}", "INCLUDEDIR=#{self.install / 'include'}", "WIN32=#{os == 'windows' ? '1': '0'}"]
     ],
     "buildsInSource":"_build",
     "exportedEnv": {


### PR DESCRIPTION
Similar issue as esy-packages/esy-freetype2#10 - we're using the cross-compiler detection as a proxy to see if we're on Windows, but this is incorrect, since the cross-compiler could be on Mac as well.